### PR TITLE
Killing pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,15 +64,6 @@
         </dependency>
     </dependencies>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.1</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Tested this on Maven v2.2.1 and v3.0.2 (on Mac) and this change throws up no warning messages.
