### PR TITLE
Log *now* instead of when the request came in.

### DIFF
--- a/src/main/java/org/webbitserver/handler/logging/SimpleLogSink.java
+++ b/src/main/java/org/webbitserver/handler/logging/SimpleLogSink.java
@@ -115,8 +115,9 @@ public class SimpleLogSink implements LogSink {
 
     protected Appendable formatLogEntry(Appendable out, HttpRequest request, String action, String data) throws IOException {
         long cumulativeTimeOfRequest = cumulativeTimeOfRequest(request);
-        formatValue(out, new Date(request.timestamp()));
-        formatValue(out, request.timestamp());
+        Date now = new Date();
+        formatValue(out, now);
+        formatValue(out, now.getTime());
         formatValue(out, cumulativeTimeOfRequest);
         formatValue(out, request.id());
         formatValue(out, address(request.remoteAddress()));


### PR DESCRIPTION
Log _now_ instead of when the request came in. Long-lived connections (WebSocket and EventSource) will log really old timestamps without this fix.

I'm not pushing this straight to joewalnes/master because I'm not 100% sure what the intention was.
