### PR TITLE
Fix for EmbeddedResourceHandler for windows

### DIFF
--- a/src/main/java/org/webbitserver/handler/EmbeddedResourceHandler.java
+++ b/src/main/java/org/webbitserver/handler/EmbeddedResourceHandler.java
@@ -75,6 +75,9 @@ public class EmbeddedResourceHandler extends AbstractResourceHandler {
 
         private URL getResource(File file) throws IOException {
             String resourcePath = file.getPath();
+            if('/' != File.separatorChar){
+                resourcePath = resourcePath.replace(File.separatorChar, '/');
+            }
             return getClass().getClassLoader().getResource(resourcePath);
         }
     }


### PR DESCRIPTION
Small fix to allow the EmbeddedResourceHandler to work for systems whose File.separatorChar is not '/' (ie windows).
