### PR TITLE
Added support for getting request body as a byte array

### DIFF
--- a/src/main/java/org/webbitserver/HttpRequest.java
+++ b/src/main/java/org/webbitserver/HttpRequest.java
@@ -130,6 +130,11 @@ public interface HttpRequest extends DataHolder {
      */
     String body();
 
+     /**
+     * The body's byte array
+     */
+    byte[] bodyAsBytes();
+
     @Override
     HttpRequest data(String key, Object value); // Override DataHolder to provide more specific return type.
 

--- a/src/main/java/org/webbitserver/netty/NettyHttpRequest.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpRequest.java
@@ -139,6 +139,11 @@ public class NettyHttpRequest implements org.webbitserver.HttpRequest {
     }
 
     @Override
+    public byte[] bodyAsBytes() {
+        return httpRequest.getContent().array();
+    }
+
+    @Override
     public Map<String, Object> data() {
         return data;
     }

--- a/src/main/java/org/webbitserver/stub/StubHttpRequest.java
+++ b/src/main/java/org/webbitserver/stub/StubHttpRequest.java
@@ -139,6 +139,11 @@ public class StubHttpRequest extends StubDataHolder implements HttpRequest {
         return body;
     }
 
+    @Override
+    public byte[] bodyAsBytes() {
+        return body.getBytes();
+    }
+
     public StubHttpRequest body(String body) {
         this.body = body;
         return this;

--- a/src/main/java/org/webbitserver/wrapper/HttpRequestWrapper.java
+++ b/src/main/java/org/webbitserver/wrapper/HttpRequestWrapper.java
@@ -121,6 +121,11 @@ public class HttpRequestWrapper implements HttpRequest {
     }
 
     @Override
+    public byte[] bodyAsBytes() {
+        return request.bodyAsBytes();
+    }
+
+    @Override
     public Map<String, Object> data() {
         return request.data();
     }

--- a/src/test/java/org/webbitserver/handler/PostTest.java
+++ b/src/test/java/org/webbitserver/handler/PostTest.java
@@ -6,6 +6,7 @@ import org.webbitserver.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -60,5 +61,18 @@ public class PostTest {
         }).start();
         String result = contents(httpPost(webServer, "/", "b=foo&a=hello%20world&c=d&b=duplicate"));
         assertEquals("keys=[a, b, c]", result);
+    }
+
+    @Test
+    public void exposesPostBodyAsBytes() throws IOException {
+        webServer.add(new HttpHandler() {
+            @Override
+            public void handleHttpRequest(HttpRequest request, HttpResponse response, HttpControl control) throws Exception {
+                response.content(Arrays.toString(request.bodyAsBytes())).end();
+            }
+        }).start();
+        byte[] byteArray = new byte[] {87, 79, 87, 46, 46, 46};
+        String result = contents(httpPost(webServer, "/", new String(byteArray)));
+        assertEquals(Arrays.toString(byteArray), result);
     }
 }


### PR DESCRIPTION
This is useful for binary data as it isn't reliable (or easy!) to turn the encoded string back to a byte array.

Hope this patch makes sense.

This was to solve the problem of handling gzipped bodies.  I considered checking "Content-Encoding" in the request header and doing this transparently which might be an idea as well.

However other binary data would probably need access to the byte array so I left it. 
