### PR TITLE
WebSocketConnection.version() method and improved logging.

### DIFF
--- a/src/main/java/org/webbitserver/HttpControl.java
+++ b/src/main/java/org/webbitserver/HttpControl.java
@@ -12,11 +12,11 @@ public interface HttpControl extends Executor {
 
     WebSocketConnection upgradeToWebSocketConnection(WebSocketHandler handler);
 
-    WebSocketConnection createWebSocketConnection();
+    WebSocketConnection webSocketConnection();
 
     EventSourceConnection upgradeToEventSourceConnection(EventSourceHandler handler);
 
-    EventSourceConnection createEventSourceConnection();
+    EventSourceConnection eventSourceConnection();
 
     Executor handlerExecutor();
 }

--- a/src/main/java/org/webbitserver/HttpRequest.java
+++ b/src/main/java/org/webbitserver/HttpRequest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 public interface HttpRequest extends DataHolder {
 
     String COOKIE_HEADER = "Cookie";
+    String WEBSOCKET_VERSION = "WEBSOCKET_VERSION";
 
     String uri();
 

--- a/src/main/java/org/webbitserver/WebSocketConnection.java
+++ b/src/main/java/org/webbitserver/WebSocketConnection.java
@@ -3,6 +3,12 @@ package org.webbitserver;
 import java.util.concurrent.Executor;
 
 public interface WebSocketConnection extends Executor, DataHolder {
+    enum Version {
+        HIXIE_75,
+        HIXIE_76,
+        HYBI_10
+    }
+
     HttpRequest httpRequest();
 
     /**
@@ -35,4 +41,6 @@ public interface WebSocketConnection extends Executor, DataHolder {
     WebSocketConnection data(String key, Object value); // Override DataHolder to provide more specific return type.
 
     Executor handlerExecutor();
+
+    Version version();
 }

--- a/src/main/java/org/webbitserver/handler/logging/LoggingHandler.java
+++ b/src/main/java/org/webbitserver/handler/logging/LoggingHandler.java
@@ -48,24 +48,24 @@ public class LoggingHandler implements HttpHandler {
             private LoggingEventSourceConnection loggingEventSourceConnection;
 
             @Override
-            public WebSocketConnection createWebSocketConnection() {
+            public WebSocketConnection webSocketConnection() {
                 return loggingWebSocketConnection;
             }
 
             @Override
             public WebSocketConnection upgradeToWebSocketConnection(WebSocketHandler handler) {
-                loggingWebSocketConnection = new LoggingWebSocketConnection(logSink, super.createWebSocketConnection());
+                loggingWebSocketConnection = new LoggingWebSocketConnection(logSink, super.webSocketConnection());
                 return super.upgradeToWebSocketConnection(new LoggingWebSocketHandler(logSink, loggingWebSocketConnection, handler));
             }
 
             @Override
-            public EventSourceConnection createEventSourceConnection() {
+            public EventSourceConnection eventSourceConnection() {
                 return loggingEventSourceConnection;
             }
 
             @Override
             public EventSourceConnection upgradeToEventSourceConnection(EventSourceHandler handler) {
-                loggingEventSourceConnection = new LoggingEventSourceConnection(logSink, super.createEventSourceConnection());
+                loggingEventSourceConnection = new LoggingEventSourceConnection(logSink, super.eventSourceConnection());
                 return super.upgradeToEventSourceConnection(new LoggingEventSourceHandler(logSink, loggingEventSourceConnection, handler));
             }
         };

--- a/src/main/java/org/webbitserver/handler/logging/SimpleLogSink.java
+++ b/src/main/java/org/webbitserver/handler/logging/SimpleLogSink.java
@@ -51,42 +51,42 @@ public class SimpleLogSink implements LogSink {
 
     @Override
     public void webSocketConnectionOpen(WebSocketConnection connection) {
-        custom(connection.httpRequest(), "WEB-SOCKET-OPEN", null);
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-OPEN", null);
     }
 
     @Override
     public void webSocketConnectionClose(WebSocketConnection connection) {
-        custom(connection.httpRequest(), "WEB-SOCKET-CLOSE", null);
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-CLOSE", null);
     }
 
     @Override
     public void webSocketInboundData(WebSocketConnection connection, String data) {
-        custom(connection.httpRequest(), "WEB-SOCKET-IN", data);
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-IN-STRING", data);
     }
 
     @Override
     public void webSocketInboundData(WebSocketConnection connection, byte[] data) {
-        custom(connection.httpRequest(), "WEB-SOCKET-IN", toHex(data));
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-IN-HEX", toHex(data));
     }
 
     @Override
     public void webSocketInboundPong(WebSocketConnection connection, String message) {
-        custom(connection.httpRequest(), "WEB-SOCKET-IN-PONG", message);
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-IN-PONG", message);
     }
 
     @Override
     public void webSocketOutboundData(WebSocketConnection connection, String data) {
-        custom(connection.httpRequest(), "WEB-SOCKET-OUT", data);
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-OUT-STRING", data);
     }
 
     @Override
     public void webSocketOutboundData(WebSocketConnection connection, byte[] data) {
-        custom(connection.httpRequest(), "WEB-SOCKET-OUT", toHex(data));
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-OUT-HEX", toHex(data));
     }
 
     @Override
     public void webSocketOutboundPing(WebSocketConnection connection, String message) {
-        custom(connection.httpRequest(), "WEB-SOCKET-OUT-PING", message);
+        custom(connection.httpRequest(), "WEB-SOCKET-" + connection.version().name() + "-PING", message);
     }
 
     @Override

--- a/src/main/java/org/webbitserver/netty/NettyHttpControl.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpControl.java
@@ -2,12 +2,7 @@ package org.webbitserver.netty;
 
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.webbitserver.EventSourceHandler;
-import org.webbitserver.HttpControl;
-import org.webbitserver.HttpHandler;
-import org.webbitserver.HttpRequest;
-import org.webbitserver.HttpResponse;
-import org.webbitserver.WebSocketHandler;
+import org.webbitserver.*;
 
 import java.util.Iterator;
 import java.util.concurrent.Executor;
@@ -26,6 +21,8 @@ public class NettyHttpControl implements HttpControl {
     private HttpRequest defaultRequest;
     private HttpResponse defaultResponse;
     private HttpControl defaultControl;
+    private NettyWebSocketConnection nettyWebSocketConnection;
+    private NettyEventSourceConnection nettyEventSourceConnection;
 
     public NettyHttpControl(Iterator<HttpHandler> handlerIterator,
                             Executor executor,
@@ -78,7 +75,7 @@ public class NettyHttpControl implements HttpControl {
 
     @Override
     public NettyWebSocketConnection upgradeToWebSocketConnection(WebSocketHandler handler) {
-        NettyWebSocketConnection webSocketConnection = createWebSocketConnection();
+        NettyWebSocketConnection webSocketConnection = webSocketConnection();
         new NettyWebSocketChannelHandler(
                 executor,
                 handler,
@@ -94,13 +91,16 @@ public class NettyHttpControl implements HttpControl {
     }
 
     @Override
-    public NettyWebSocketConnection createWebSocketConnection() {
-        return new NettyWebSocketConnection(executor, nettyHttpRequest, ctx);
+    public NettyWebSocketConnection webSocketConnection() {
+        if(nettyWebSocketConnection == null) {
+            nettyWebSocketConnection = new NettyWebSocketConnection(executor, nettyHttpRequest, ctx);
+        }
+        return nettyWebSocketConnection;
     }
 
     @Override
     public NettyEventSourceConnection upgradeToEventSourceConnection(EventSourceHandler handler) {
-        NettyEventSourceConnection eventSourceConnection = createEventSourceConnection();
+        NettyEventSourceConnection eventSourceConnection = eventSourceConnection();
         new NettyEventSourceChannelHandler(
                 executor,
                 handler,
@@ -116,8 +116,11 @@ public class NettyHttpControl implements HttpControl {
     }
 
     @Override
-    public NettyEventSourceConnection createEventSourceConnection() {
-        return new NettyEventSourceConnection(executor, nettyHttpRequest, ctx);
+    public NettyEventSourceConnection eventSourceConnection() {
+        if(nettyEventSourceConnection == null) {
+            nettyEventSourceConnection = new NettyEventSourceConnection(executor, nettyHttpRequest, ctx);
+        }
+        return nettyEventSourceConnection;
     }
 
     @Override

--- a/src/main/java/org/webbitserver/netty/NettyWebSocketChannelHandler.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebSocketChannelHandler.java
@@ -15,6 +15,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.websocket.WebSocketFrame;
 import org.jboss.netty.handler.codec.http.websocket.WebSocketFrameDecoder;
 import org.jboss.netty.handler.codec.http.websocket.WebSocketFrameEncoder;
+import org.webbitserver.WebSocketConnection;
 import org.webbitserver.WebSocketHandler;
 import org.webbitserver.helpers.Base64;
 
@@ -86,14 +87,17 @@ public class NettyWebSocketChannelHandler extends SimpleChannelUpstreamHandler {
 
     protected void prepareConnection(HttpRequest req, HttpResponse res, ChannelHandlerContext ctx) {
         if (isHybi10WebSocketRequest(req)) {
+            this.webSocketConnection.setVersion(WebSocketConnection.Version.HYBI_10);
             upgradeResponseHybi10(req, res);
             ctx.getChannel().write(res);
             adjustPipelineToHybi(ctx);
         } else if (isHixie76WebSocketRequest(req)) {
+            this.webSocketConnection.setVersion(WebSocketConnection.Version.HIXIE_76);
             upgradeResponseHixie76(req, res);
             ctx.getChannel().write(res);
             adjustPipelineToHixie(ctx);
         } else {
+            this.webSocketConnection.setVersion(WebSocketConnection.Version.HIXIE_75);
             upgradeResponseHixie75(req, res);
             ctx.getChannel().write(res);
             adjustPipelineToHixie(ctx);

--- a/src/main/java/org/webbitserver/netty/NettyWebSocketConnection.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebSocketConnection.java
@@ -15,6 +15,7 @@ public class NettyWebSocketConnection implements WebSocketConnection {
     private final Executor executor;
     private final NettyHttpRequest nettyHttpRequest;
     private final ChannelHandlerContext ctx;
+    private Version version;
 
     public NettyWebSocketConnection(Executor executor, NettyHttpRequest nettyHttpRequest, ChannelHandlerContext ctx) {
         this.executor = executor;
@@ -84,4 +85,12 @@ public class NettyWebSocketConnection implements WebSocketConnection {
         handlerExecutor().execute(command);
     }
 
+    void setVersion(Version version) {
+        this.version = version;
+    }
+
+    @Override
+    public Version version() {
+        return version;
+    }
 }

--- a/src/main/java/org/webbitserver/stub/StubConnection.java
+++ b/src/main/java/org/webbitserver/stub/StubConnection.java
@@ -20,6 +20,7 @@ public class StubConnection extends StubDataHolder implements EventSourceConnect
     private final List<String> sentPings = new LinkedList<String>();
     private boolean closed = false;
     private HttpRequest httpRequest;
+    private Version version = Version.HYBI_10;
 
     public StubConnection(HttpRequest httpRequest) {
         this.httpRequest = httpRequest;
@@ -92,6 +93,16 @@ public class StubConnection extends StubDataHolder implements EventSourceConnect
 
     @Override
     public Executor handlerExecutor() {
+        return this;
+    }
+
+    @Override
+    public Version version() {
+        return version;
+    }
+
+    public StubConnection version(Version version) {
+        this.version = version;
         return this;
     }
 

--- a/src/main/java/org/webbitserver/stub/StubHttpControl.java
+++ b/src/main/java/org/webbitserver/stub/StubHttpControl.java
@@ -75,7 +75,7 @@ public class StubHttpControl implements HttpControl {
     }
 
     @Override
-    public WebSocketConnection createWebSocketConnection() {
+    public WebSocketConnection webSocketConnection() {
         return this.webSocketConnection;
     }
 
@@ -87,13 +87,9 @@ public class StubHttpControl implements HttpControl {
     }
 
     @Override
-    public EventSourceConnection createEventSourceConnection() {
+    public EventSourceConnection eventSourceConnection() {
         throw new UnsupportedOperationException();
 //        return this.webSocketConnection;
-    }
-
-    public WebSocketConnection webSocketConnection() {
-        return this.webSocketConnection;
     }
 
     public StubHttpControl webSocketConnection(WebSocketConnection connection) {

--- a/src/main/java/org/webbitserver/wrapper/HttpControlWrapper.java
+++ b/src/main/java/org/webbitserver/wrapper/HttpControlWrapper.java
@@ -57,8 +57,8 @@ public class HttpControlWrapper implements HttpControl {
     }
 
     @Override
-    public WebSocketConnection createWebSocketConnection() {
-        return control.createWebSocketConnection();
+    public WebSocketConnection webSocketConnection() {
+        return control.webSocketConnection();
     }
 
     @Override
@@ -67,8 +67,8 @@ public class HttpControlWrapper implements HttpControl {
     }
 
     @Override
-    public EventSourceConnection createEventSourceConnection() {
-        return control.createEventSourceConnection();
+    public EventSourceConnection eventSourceConnection() {
+        return control.eventSourceConnection();
     }
 
     @Override

--- a/src/main/java/org/webbitserver/wrapper/WebSocketConnectionWrapper.java
+++ b/src/main/java/org/webbitserver/wrapper/WebSocketConnectionWrapper.java
@@ -89,6 +89,11 @@ public class WebSocketConnectionWrapper implements WebSocketConnection {
     }
 
     @Override
+    public Version version() {
+        return connection.version();
+    }
+
+    @Override
     public void execute(Runnable command) {
         connection.execute(command);
     }


### PR DESCRIPTION
Added a WebSocketConnection.version() method to know what protocol version the client is using. Also changed logging to print the version.

While doing this I realised that two instances of WebSocketConnection was created, so I implemented field caching in createWebSocketConnection() and renamed it to webSocketConnection() to reflect that it doesn't create a new instance every time.
