### PR TITLE
Garbage reduction for outbound messages

### DIFF
--- a/src/main/java/org/webbitserver/helpers/UTF8Output.java
+++ b/src/main/java/org/webbitserver/helpers/UTF8Output.java
@@ -45,7 +45,12 @@ public class UTF8Output {
     private int state = UTF8_ACCEPT;
     private int codep = 0;
 
-    private final StringBuilder stringBuilder = new StringBuilder();
+    private final StringBuilder stringBuilder;
+
+    public UTF8Output(byte[] bytes) {
+        stringBuilder = new StringBuilder(bytes.length);
+        write(bytes);
+    }
 
     public void write(byte[] bytes) {
         for (byte b : bytes) {

--- a/src/main/java/org/webbitserver/netty/EncodingHybiFrame.java
+++ b/src/main/java/org/webbitserver/netty/EncodingHybiFrame.java
@@ -1,0 +1,62 @@
+package org.webbitserver.netty;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+import org.webbitserver.helpers.UTF8Output;
+
+import java.util.ArrayList;
+
+public class EncodingHybiFrame {
+
+    private final int opcode;
+    private final boolean fin;
+    private final int rsv;
+    private final ChannelBuffer data;
+
+    public EncodingHybiFrame(int opcode, boolean fin, int rsv, ChannelBuffer fragment) {
+        this.opcode = opcode;
+        this.fin = fin;
+        this.rsv = rsv;
+        this.data = fragment;
+    }
+
+    public ChannelBuffer encode() throws TooLongFrameException {
+        int b0 = 0;
+        if (fin) {
+            b0 |= (1 << 7);
+        }
+        b0 |= (rsv % 8) << 4;
+        b0 |= opcode % 128;
+
+        ChannelBuffer header;
+        int length = data.readableBytes();
+
+        if (opcode == Opcodes.OPCODE_PING && length > 125) {
+            throw new TooLongFrameException("invalid payload for PING (payload length must be <= 125, was " + length);
+        }
+
+        if (length <= 125) {
+            header = createBuffer(length + 2);
+            header.writeByte(b0);
+            header.writeByte(length);
+        } else if (length <= 0xFFFF) {
+            header = createBuffer(length + 4);
+            header.writeByte(b0);
+            header.writeByte(126);
+            header.writeByte((length >>> 8) & 0xFF);
+            header.writeByte((length) & 0xFF);
+        } else {
+            header = createBuffer(length + 10);
+            header.writeByte(b0);
+            header.writeByte(127);
+            header.writeLong(length);
+        }
+
+        return ChannelBuffers.wrappedBuffer(header, data);
+    }
+
+    private ChannelBuffer createBuffer(int length) {
+        return ChannelBuffers.buffer(length);
+    }
+}

--- a/src/main/java/org/webbitserver/netty/HybiWebSocketFrameEncoder.java
+++ b/src/main/java/org/webbitserver/netty/HybiWebSocketFrameEncoder.java
@@ -7,8 +7,8 @@ import org.jboss.netty.handler.codec.oneone.OneToOneEncoder;
 public class HybiWebSocketFrameEncoder extends OneToOneEncoder {
     @Override
     protected Object encode(ChannelHandlerContext ctx, Channel channel, Object msg) throws Exception {
-        if (msg instanceof HybiFrame) {
-            HybiFrame frame = (HybiFrame) msg;
+        if (msg instanceof EncodingHybiFrame) {
+            EncodingHybiFrame frame = (EncodingHybiFrame) msg;
             return frame.encode();
         }
         return msg;

--- a/src/main/java/org/webbitserver/netty/NettyWebSocketChannelHandler.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebSocketChannelHandler.java
@@ -67,8 +67,7 @@ public class NettyWebSocketChannelHandler extends SimpleChannelUpstreamHandler {
         try {
             handler.onOpen(this.webSocketConnection);
         } catch (Exception e) {
-            // TODO
-            e.printStackTrace();
+            exceptionHandler.uncaughtException(Thread.currentThread(), e);
         }
     }
 
@@ -231,8 +230,8 @@ public class NettyWebSocketChannelHandler extends SimpleChannelUpstreamHandler {
             public void run() {
                 try {
                     Object message = e.getMessage();
-                    if(message instanceof HybiFrame) {
-                        HybiFrame frame = (HybiFrame) message;
+                    if(message instanceof DecodingHybiFrame) {
+                        DecodingHybiFrame frame = (DecodingHybiFrame) message;
                         frame.dispatch(handler, webSocketConnection);
                     } else {
                         // Hixie 75/76

--- a/src/main/java/org/webbitserver/netty/NettyWebSocketConnection.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebSocketConnection.java
@@ -3,6 +3,7 @@ package org.webbitserver.netty;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.websocket.DefaultWebSocketFrame;
+import org.jboss.netty.util.CharsetUtil;
 import org.webbitserver.WebSocketConnection;
 
 import java.nio.charset.Charset;
@@ -32,24 +33,23 @@ public class NettyWebSocketConnection implements WebSocketConnection {
     @Override
     public NettyWebSocketConnection send(String message) {
         if (hybi) {
-            return send(new HybiFrame(Opcodes.OPCODE_TEXT, true, 0, ChannelBuffers.wrappedBuffer(message.getBytes(Charset.forName("UTF-8")))));
+            return write(new EncodingHybiFrame(Opcodes.OPCODE_TEXT, true, 0, ChannelBuffers.copiedBuffer(message, CharsetUtil.UTF_8)));
         } else {
-            ctx.getChannel().write(new DefaultWebSocketFrame(message));
-            return this;
+            return write(new DefaultWebSocketFrame(message));
         }
     }
 
     @Override
     public NettyWebSocketConnection send(byte[] message) {
-        return send(new HybiFrame(Opcodes.OPCODE_BINARY, true, 0, ChannelBuffers.wrappedBuffer(message)));
+        return write(new EncodingHybiFrame(Opcodes.OPCODE_BINARY, true, 0, ChannelBuffers.wrappedBuffer(message)));
     }
 
     @Override
     public NettyWebSocketConnection ping(String message) {
-        return send(new HybiFrame(Opcodes.OPCODE_PING, true, 0, ChannelBuffers.wrappedBuffer(message.getBytes(Charset.forName("UTF-8")))));
+        return write(new EncodingHybiFrame(Opcodes.OPCODE_PING, true, 0, ChannelBuffers.copiedBuffer(message, CharsetUtil.UTF_8)));
     }
 
-    private NettyWebSocketConnection send(HybiFrame frame) {
+    private NettyWebSocketConnection write(Object frame) {
         ctx.getChannel().write(frame);
         return this;
     }

--- a/src/test/java/org/webbitserver/helpers/UTF8OutputTest.java
+++ b/src/test/java/org/webbitserver/helpers/UTF8OutputTest.java
@@ -23,7 +23,7 @@ public class UTF8OutputTest {
         int[] bad = new int[]{
                 0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE, 0xBC, 0xCE, 0xB5, 0xED, 0xA0, 0x80, 0x65, 0x64, 0x69, 0x74, 0x65, 0x64
         };
-        UTF8Output utf8Output = new UTF8Output();
+        UTF8Output utf8Output = new UTF8Output(new byte[0]);
         for (int i : bad) {
             utf8Output.write(i);
         }
@@ -31,8 +31,7 @@ public class UTF8OutputTest {
 
 
     private void assertUtf8(String s) throws IOException {
-        UTF8Output utf8Output = new UTF8Output();
-        utf8Output.write(s.getBytes("UTF-8"));
+        UTF8Output utf8Output = new UTF8Output(s.getBytes("UTF-8"));
         assertEquals(s, utf8Output.toString());
     }
 }


### PR DESCRIPTION
Split encoding/decoding HybiFrame's so we can do less copying of byte arrays for outbound messages.
