### PR TITLE
Wrap all exceptions in WebbitException, to provide better documentation of errors

### DIFF
--- a/src/main/java/org/webbitserver/WebbitException.java
+++ b/src/main/java/org/webbitserver/WebbitException.java
@@ -1,0 +1,37 @@
+package org.webbitserver;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ExceptionEvent;
+
+/**
+ * Marker for any exceptions in the Webbit stack.
+ *
+ * This is used to ensure the exceptions we report to {@link Thread.UncaughtExceptionHandler}s are well
+ * documented and make it obvious that an error occured in Webbit. This is particularly useful for projects
+ * that make heavy use of Netty, since most of our exceptions come out of the Netty stack, and don't include
+ * Webbit code in their stack traces.
+ */
+public class WebbitException extends RuntimeException {
+    public WebbitException() {
+    }
+
+    public WebbitException(String message) {
+        super(message);
+    }
+
+    public WebbitException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WebbitException(Throwable cause) {
+        super(cause);
+    }
+
+    public static WebbitException fromExceptionEvent(ExceptionEvent e) {
+        return new WebbitException(e.getCause().getMessage() + " on " + e.getChannel().toString(), e.getCause());
+    }
+
+    public static WebbitException fromException(Throwable t, Channel channel) {
+        return new WebbitException(t.getMessage() + " on " + channel.toString(), t);
+    }
+}

--- a/src/main/java/org/webbitserver/netty/NettyEventSourceChannelHandler.java
+++ b/src/main/java/org/webbitserver/netty/NettyEventSourceChannelHandler.java
@@ -9,6 +9,7 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.webbitserver.EventSourceHandler;
+import org.webbitserver.WebbitException;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.channels.ClosedChannelException;
@@ -71,14 +72,14 @@ public class NettyEventSourceChannelHandler extends SimpleChannelUpstreamHandler
     }
 
     @Override
-    public void channelDisconnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
+    public void channelDisconnected(ChannelHandlerContext ctx, final ChannelStateEvent e) throws Exception {
         executor.execute(new Runnable() {
             @Override
             public void run() {
                 try {
                     handler.onClose(eventSourceConnection);
                 } catch (Exception e1) {
-                    exceptionHandler.uncaughtException(Thread.currentThread(), e1);
+                    exceptionHandler.uncaughtException(Thread.currentThread(), WebbitException.fromException(e1, e.getChannel()));
                 }
             }
         });
@@ -98,7 +99,7 @@ public class NettyEventSourceChannelHandler extends SimpleChannelUpstreamHandler
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    ioExceptionHandler.uncaughtException(thread, e.getCause());
+                    ioExceptionHandler.uncaughtException(thread, WebbitException.fromExceptionEvent(e));
                 }
             });
         }

--- a/src/main/java/org/webbitserver/netty/NettyHttpChannelHandler.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpChannelHandler.java
@@ -8,6 +8,7 @@ import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.webbitserver.HttpControl;
 import org.webbitserver.HttpHandler;
+import org.webbitserver.WebbitException;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
@@ -49,7 +50,7 @@ public class NettyHttpChannelHandler extends SimpleChannelUpstreamHandler {
         }
     }
 
-    private void handleHttpRequest(ChannelHandlerContext ctx, MessageEvent messageEvent, HttpRequest httpRequest) {
+    private void handleHttpRequest(final ChannelHandlerContext ctx, MessageEvent messageEvent, HttpRequest httpRequest) {
         final NettyHttpRequest nettyHttpRequest = new NettyHttpRequest(messageEvent, httpRequest, id, timestamp);
         final NettyHttpResponse nettyHttpResponse = new NettyHttpResponse(
                 ctx, new DefaultHttpResponse(HTTP_1_1, OK), isKeepAlive(httpRequest), exceptionHandler, ioExceptionHandler);
@@ -63,7 +64,7 @@ public class NettyHttpChannelHandler extends SimpleChannelUpstreamHandler {
                 try {
                     control.nextHandler(nettyHttpRequest, nettyHttpResponse);
                 } catch (Exception exception) {
-                    exceptionHandler.uncaughtException(Thread.currentThread(), exception);
+                    exceptionHandler.uncaughtException(Thread.currentThread(), WebbitException.fromException(exception, ctx.getChannel()));
                 }
             }
         });
@@ -79,7 +80,7 @@ public class NettyHttpChannelHandler extends SimpleChannelUpstreamHandler {
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    ioExceptionHandler.uncaughtException(thread, e.getCause());
+                    ioExceptionHandler.uncaughtException(thread, WebbitException.fromExceptionEvent(e));
                 }
             });
         }

--- a/src/main/java/org/webbitserver/netty/NettyHttpResponse.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpResponse.java
@@ -8,6 +8,7 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.util.CharsetUtil;
+import org.webbitserver.WebbitException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -114,7 +115,7 @@ public class NettyHttpResponse implements org.webbitserver.HttpResponse {
         content(message);
         flushResponse();
 
-        exceptionHandler.uncaughtException(Thread.currentThread(), error);
+        exceptionHandler.uncaughtException(Thread.currentThread(), WebbitException.fromException(error, ctx.getChannel()));
 
         return this;
     }
@@ -143,7 +144,7 @@ public class NettyHttpResponse implements org.webbitserver.HttpResponse {
                 future.addListener(ChannelFutureListener.CLOSE);
             }
         } catch (Exception e) {
-            ioExceptionHandler.uncaughtException(Thread.currentThread(), e);
+            exceptionHandler.uncaughtException(Thread.currentThread(), WebbitException.fromException(e, ctx.getChannel()));
         }
     }
 

--- a/src/main/java/org/webbitserver/netty/NettyWebSocketConnection.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebSocketConnection.java
@@ -1,12 +1,12 @@
 package org.webbitserver.netty;
 
 import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.http.websocket.DefaultWebSocketFrame;
 import org.jboss.netty.util.CharsetUtil;
 import org.webbitserver.WebSocketConnection;
 
-import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
@@ -103,5 +103,9 @@ public class NettyWebSocketConnection implements WebSocketConnection {
     void setHybiWebSocketVersion(int webSocketVersion) {
         setVersion("Sec-WebSocket-Version-" + webSocketVersion);
         hybi = true;
+    }
+
+    Channel getChannel() {
+        return ctx.getChannel();
     }
 }


### PR DESCRIPTION
It shows the details of the connection (if applicable) when an error occurs.

It ensures stack traces conntain "Webbit" somewhere. Since most of our code is just
instantiation of Netty code a lot of exceptions it throws don't contain any Webbit
code in the stack trace. When using Netty for a number of different networking services
it's not very obvious where an exception came from.
