### PR TITLE
Proposed fix for wss:// protocol mismatch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Nathan Mische
 Phil Dawes
 Alex Silverstein
 Michael Rykov
+Justin Long

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+0.4.7 (2012-03-29)
+==================
+
+[Full changelog](https://github.com/webbit/webbit/compare/v0.4.6...v0.4.7)
+
+* Now returns the appropriate protocol when responding to  [secure websockets](https://github.com/igrigorik/em-websocket/issues/82). (Justin Long)
+
 0.4.6 (2012-02-23)
 ==================
 

--- a/src/main/java/org/webbitserver/netty/Hixie75.java
+++ b/src/main/java/org/webbitserver/netty/Hixie75.java
@@ -62,6 +62,6 @@ public class Hixie75 implements WebSocketVersion {
     }
     
     private String getWebSocketProtocol(HttpRequest req) {
-  	  if(req.getHeader(HttpHeaders.Names.ORIGIN).matches("/^https/")) { return "wss"; } else { return "ws"; }
+  	  if(req.getHeader(HttpHeaders.Names.ORIGIN).matches("/^https:\\/\\//")) { return "wss://"; } else { return "ws://"; }
     }
 }

--- a/src/main/java/org/webbitserver/netty/Hixie76.java
+++ b/src/main/java/org/webbitserver/netty/Hixie76.java
@@ -91,6 +91,6 @@ public class Hixie76 implements WebSocketVersion {
     }
   
 	  private String getWebSocketProtocol(HttpRequest req) {
-		  if(req.getHeader(HttpHeaders.Names.ORIGIN).matches("/^https/")) { return "wss"; } else { return "ws"; }
+		  if(req.getHeader(HttpHeaders.Names.ORIGIN).matches("/^https:\\/\\//")) { return "wss://"; } else { return "ws://"; }
 	  }
 }


### PR DESCRIPTION
I believe this will solve the issue where protocol mismatches were occuring when using Safari and other Apple products. The fix does a regex on the request ORIGIN and determines if it was HTTPS, thereby setting the response protocol to "wss://".

This was listed as a TODO in the code but looks like no one ever patched it up. Let me know if there's any issues and I will fix promptly.
