### PR TITLE
Release all Threads on Webserver#stop()

### DIFF
--- a/src/main/java/org/webbitserver/netty/NettyWebServer.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebServer.java
@@ -49,7 +49,6 @@ import static org.jboss.netty.channel.Channels.pipeline;
 public class NettyWebServer implements WebServer {
     private static final long DEFAULT_STALE_CONNECTION_TIMEOUT = 5000;
 
-    private final Executor startStopExecutor = Executors.newSingleThreadExecutor();
     private final SocketAddress socketAddress;
     private final URI publicUri;
     private final List<HttpHandler> handlers = new ArrayList<HttpHandler>();
@@ -219,7 +218,10 @@ public class NettyWebServer implements WebServer {
                 return NettyWebServer.this;
             }
         });
-        startStopExecutor.execute(future);
+        // don't use Executor here - it's just another resource we need to manage -
+        // thread creation on startup should be fine
+        final Thread thread = new Thread(future, "WEBBIT-STARTUP-THREAD");
+        thread.start();
         return future;
     }
 
@@ -254,7 +256,10 @@ public class NettyWebServer implements WebServer {
                 return NettyWebServer.this;
             }
         });
-        startStopExecutor.execute(future);
+        // don't use Executor here - it's just another resource we need to manage -
+        // thread creation on shutdown should be fine
+        final Thread thread = new Thread(future, "WEBBIT-SHUTDOW-THREAD");
+        thread.start();
         return future;
     }
 

--- a/src/test/java/org/webbitserver/netty/NettyWebServerTest.java
+++ b/src/test/java/org/webbitserver/netty/NettyWebServerTest.java
@@ -29,7 +29,6 @@ public class NettyWebServerTest {
         server.stop().get();
     }
 
-    @Ignore // See https://github.com/webbit/webbit/issues/41
     @Test
     public void stopsServerCleanlyNotLeavingResourcesHanging() throws Exception {
         int threadCountStart = getCurrentThreadCount();


### PR DESCRIPTION
I just upgraded to 0.4.7 and saw my test failing. I do check against left-over threads and Webbit leaves the startup/shutdown thread running ie the executor is never shut down. This pull-request removes that executor entirely since keeping that thread around just for that purpose seems odd and adds additional managing costs on the server since the resources should be closed. 

Yet, if that single threaded executor was added in order to prevent "concurrent" shutdowns / startups I have some more options so feedback is welcome. This pull-request might be related to https://github.com/webbit/webbit/issues/41 - I un-ignored the testcase and it passes so this might be related.
