### PR TITLE
Fix for corrupted POST Data

### DIFF
--- a/src/main/java/org/webbitserver/netty/NettyHttpRequest.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpRequest.java
@@ -1,5 +1,6 @@
 package org.webbitserver.netty;
 
+import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.util.CharsetUtil;
@@ -137,7 +138,10 @@ public class NettyHttpRequest implements org.webbitserver.HttpRequest {
 
     @Override
     public byte[] bodyAsBytes() {
-        return httpRequest.getContent().array();
+        ChannelBuffer buffer = httpRequest.getContent();
+        byte[] body = new byte[buffer.readableBytes()];
+        buffer.getBytes(buffer.readerIndex(), body);
+        return body;
     }
 
     @Override


### PR DESCRIPTION
Its a bug in webbit as you relay on ChannelBuffer.array(). This is a problem as:

```
You don't check if the ChannelBuffer is really backed by an array which would for example not the case with direct buffers
You don' respect the readerIndex and WriterIndex
```

It worked before as we did a lot more buffer copies and so you was lucky enough the the ChannelBuffer was backed by an array which was exact the size of the content. This is not the case anymore as we use slice(..) when possible to save a memory copy. I will issue an pull request in webbit with the fix.
