### PR TITLE
Fix for decoding query parameters containing special characters.

### DIFF
--- a/src/main/java/org/webbitserver/netty/NettyHttpRequest.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpRequest.java
@@ -103,7 +103,7 @@ public class NettyHttpRequest implements org.webbitserver.HttpRequest {
 
     private QueryParameters parsedQueryParams() {
         if (queryParameters == null) {
-            queryParameters = new QueryParameters(URI.create(uri()).getQuery());
+            queryParameters = new QueryParameters(URI.create(uri()).getRawQuery());
         }
         return queryParameters;
     }

--- a/src/test/java/org/webbitserver/netty/NettyHttpRequestTest.java
+++ b/src/test/java/org/webbitserver/netty/NettyHttpRequestTest.java
@@ -1,0 +1,27 @@
+package org.webbitserver.netty;
+
+import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.junit.Test;
+import org.webbitserver.netty.NettyHttpRequest;
+
+import static org.junit.Assert.assertEquals;
+
+public class NettyHttpRequestTest {
+
+    @Test
+    public void decodesQueryParams() {
+        HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "http://example.com/?foo=bar");
+        NettyHttpRequest nhr = new NettyHttpRequest(null, httpRequest, null, 0L);
+        assertEquals(nhr.queryParam("foo"), "bar");
+    }
+
+    @Test
+    public void decodesQueryParamsContainingEncodedEquals() {
+        HttpRequest httpRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.GET, "http://example.com/?foo=a%2Bb%3Dc");
+        NettyHttpRequest nhr = new NettyHttpRequest(null, httpRequest, null, 0L);
+        assertEquals(nhr.queryParam("foo"), "a+b=c");
+    }
+}


### PR DESCRIPTION
It looks like query parameters aren't being decoded properly when they contain special characters (such as encoded '+' or '='). I think this change fixes the problem.
