### PR TITLE
Add support for chunked responses

### DIFF
--- a/src/main/java/org/webbitserver/HttpResponse.java
+++ b/src/main/java/org/webbitserver/HttpResponse.java
@@ -21,6 +21,13 @@ public interface HttpResponse {
      */
     HttpResponse charset(Charset charset);
 
+     /**
+     * Turns the response into a chunked response
+     * <p/>
+     * after this method is called, {@link #write(String)} should be used to send chunks
+     */
+    HttpResponse chunked();
+
     /**
      * Current Charset used to encode to response as.
      *

--- a/src/main/java/org/webbitserver/stub/StubHttpResponse.java
+++ b/src/main/java/org/webbitserver/stub/StubHttpResponse.java
@@ -2,6 +2,8 @@ package org.webbitserver.stub;
 
 import org.webbitserver.HttpResponse;
 import org.webbitserver.helpers.DateHelper;
+import org.jboss.netty.handler.codec.http.HttpHeaders.Names;
+import org.jboss.netty.handler.codec.http.HttpHeaders.Values;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,6 +30,7 @@ public class StubHttpResponse implements HttpResponse {
     private ByteArrayOutputStream contents = new ByteArrayOutputStream();
     private List<HttpCookie> cookies = new ArrayList<HttpCookie>();
 
+
     @Override
     public StubHttpResponse charset(Charset charset) {
         this.charset = charset;
@@ -37,6 +40,12 @@ public class StubHttpResponse implements HttpResponse {
     @Override
     public Charset charset() {
         return charset;
+    }
+
+    @Override
+    public StubHttpResponse chunked() {
+        header(Names.TRANSFER_ENCODING, Values.CHUNKED);
+        return this;
     }
 
     @Override

--- a/src/main/java/org/webbitserver/wrapper/HttpResponseWrapper.java
+++ b/src/main/java/org/webbitserver/wrapper/HttpResponseWrapper.java
@@ -45,6 +45,12 @@ public class HttpResponseWrapper implements HttpResponse {
     }
 
     @Override
+    public HttpResponseWrapper chunked() {
+         response.chunked();
+         return this;
+    }
+
+    @Override
     public HttpResponseWrapper status(int status) {
         response.status(status);
         return this;

--- a/src/test/java/org/webbitserver/ChunkedResponseTest.java
+++ b/src/test/java/org/webbitserver/ChunkedResponseTest.java
@@ -1,0 +1,60 @@
+package org.webbitserver;
+
+import org.junit.After;
+import org.junit.Test;
+import org.webbitserver.HttpControl;
+import org.webbitserver.HttpHandler;
+import org.webbitserver.HttpRequest;
+import org.webbitserver.HttpResponse;
+import org.webbitserver.WebServer;
+
+
+import java.net.URLConnection;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+import static org.webbitserver.WebServers.createWebServer;
+import static org.webbitserver.testutil.HttpClient.httpGet;
+
+public class ChunkedResponseTest {
+    private WebServer webServer = createWebServer(12345);
+
+    @After
+    public void die() throws InterruptedException, ExecutionException {
+        webServer.stop().get();
+    }
+
+     @Test
+    public void streamingViaChunks() throws Exception {
+        webServer.add("/chunked", new HttpHandler() {
+            @Override
+            public void handleHttpRequest(HttpRequest req, final HttpResponse res, HttpControl control) {
+                control.execute(new Runnable() { 
+                    public void run() {
+                        res.chunked();
+                        try{Thread.sleep(10);}catch (Exception ex){}
+                        res.write("chunk1");
+                        try{Thread.sleep(10);}catch (Exception ex){}
+                        res.write("chunk2");
+                        try{Thread.sleep(10);}catch (Exception ex){}
+                        res.end();
+                    }});
+            }
+        }).start().get();
+        
+
+        URLConnection conn = httpGet(webServer, "/chunked");
+
+        assertTrue("should contain chunks", stringify(conn.getInputStream()).equals("chunk1chunk2"));
+        assertTrue("should contain Transfer-Encoding header", conn.getHeaderFields().get("Transfer-Encoding") != null);
+        assertTrue("should have chunked value in Transfer encoding header",conn.getHeaderFields().get("Transfer-Encoding").get(0).equals("chunked"));
+    }
+
+    private static String stringify(java.io.InputStream is) {
+        java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
+    }
+    
+   
+}


### PR DESCRIPTION
This changeset provides a simple way to implement HTTP streaming.

About the implementation:
- HttpResponse#chunked signals that the response is going to be a chunked one (i.e. "Transfer-Encoding: chunked")
- calling HttpResponse#write afterwards will write chunks to the channel
- often times streaming is continuous (i.e. response#end never gets called) unless staleConnectionTimeout kicks in
- however, if response#end does get called, make sure to write a DefaultHttpChunk with 0 byte to the channel to signal the browser that streaming is over
