### PR TITLE
adding support for cookie attributes

### DIFF
--- a/src/main/java/org/webbitserver/helpers/InboundCookieParser.java
+++ b/src/main/java/org/webbitserver/helpers/InboundCookieParser.java
@@ -3,27 +3,33 @@ package org.webbitserver.helpers;
 import java.net.HttpCookie;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import org.jboss.netty.handler.codec.http.CookieDecoder;
+import org.jboss.netty.handler.codec.http.Cookie;
 
-/**
- * A rather simplistic parser of "Cookie:" headers.
- */
+
 public class InboundCookieParser {
     public static List<HttpCookie> parse(List<String> headerValues) {
         List<HttpCookie> result = new ArrayList<HttpCookie>();
         for (String headerValue : headerValues) {
-            String[] nvPairs = headerValue.split(";");
-            for (String nvPair : nvPairs) {
-                String[] nameAndValue = nvPair.split("=");
-                if (nameAndValue[1].startsWith("\"")) {
-                    nameAndValue[1] = nameAndValue[1].substring(1);
-                }
-                if (nameAndValue[1].endsWith("\"")) {
-                    nameAndValue[1] = nameAndValue[1].substring(0, nameAndValue[1].length() - 1);
-                }
-                result.add(new HttpCookie(nameAndValue[0], nameAndValue[1]));
-            }
+            result.addAll(toHttpCookie(new CookieDecoder().decode(headerValue)));
         }
         return result;
     }
 
+    private static List<HttpCookie> toHttpCookie(Set<Cookie> nettyCookies) {
+        List<HttpCookie> result = new ArrayList<HttpCookie>();
+        for (Cookie n : nettyCookies) {
+                HttpCookie cookie =  new HttpCookie(n.getName(),n.getValue());
+                cookie.setSecure(n.isSecure());
+                cookie.setPath(n.getPath());
+                cookie.setDomain(n.getDomain());
+                cookie.setMaxAge(Long.valueOf(n.getMaxAge()));
+                cookie.setDiscard(n.isDiscard());
+                cookie.setVersion(n.getVersion());
+                result.add(cookie);
+            }
+        return result;   
+    }
 }
+

--- a/src/main/java/org/webbitserver/netty/NettyHttpResponse.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpResponse.java
@@ -11,6 +11,9 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.util.CharsetUtil;
 import org.webbitserver.WebbitException;
 import org.webbitserver.helpers.DateHelper;
+import org.jboss.netty.handler.codec.http.CookieEncoder;
+import org.jboss.netty.handler.codec.http.DefaultCookie;
+import org.jboss.netty.handler.codec.http.Cookie;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -96,7 +99,17 @@ public class NettyHttpResponse implements org.webbitserver.HttpResponse {
 
     @Override
     public NettyHttpResponse cookie(HttpCookie httpCookie) {
-        return header(HttpHeaders.Names.SET_COOKIE, httpCookie.toString());
+        Cookie nettyCookie = new DefaultCookie(httpCookie.getName(),httpCookie.getValue());
+        nettyCookie.setDomain(httpCookie.getDomain());
+        nettyCookie.setPath(httpCookie.getPath());
+        nettyCookie.setSecure(httpCookie.getSecure());
+        nettyCookie.setMaxAge((int)httpCookie.getMaxAge());
+        nettyCookie.setVersion(httpCookie.getVersion());
+        nettyCookie.setDiscard(httpCookie.getDiscard());
+        nettyCookie.setHttpOnly(true);
+        CookieEncoder encoder = new CookieEncoder(true);
+        encoder.addCookie(nettyCookie);
+        return header(HttpHeaders.Names.SET_COOKIE, encoder.encode());
     }
 
     @Override


### PR DESCRIPTION
Replace simplistic cookie handling with a solution backed by netty's `org.jboss.netty.handler.codec.http.CookieEncoder` and `org.jboss.netty.handler.codec.http.CookieDecoder`. 

After this patch, one can maintain various attributes on cookies (maxAge, domain, isSecure etc. etc.)
