### PR TITLE
introducing HttpListener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ echo: test dist/$(LIBRARY)-all-in-one.jar
 	java -Xmx256m -cp $(CLASSPATH):dist/$(LIBRARY)-all-in-one.jar:build/$(LIBRARY)-tests.jar samples.echo.Main
 .PHONY: echo
 
+# Run Hello server 
+hello: test dist/$(LIBRARY)-all-in-one.jar
+	java -Xmx256m -cp $(CLASSPATH):dist/$(LIBRARY)-all-in-one.jar:build/$(LIBRARY)-tests.jar samples.hello.Main
+.PHONY: hello
+
 # Function to find files in directory with suffix. $(call find,dir,ext)
 find = $(shell find $(1) -name '*.$(2)')
 

--- a/src/main/java/org/webbitserver/HttpControl.java
+++ b/src/main/java/org/webbitserver/HttpControl.java
@@ -18,5 +18,7 @@ public interface HttpControl extends Executor {
 
     EventSourceConnection eventSourceConnection();
 
+    void listener(HttpListener listener);
+
     Executor handlerExecutor();
 }

--- a/src/main/java/org/webbitserver/HttpListener.java
+++ b/src/main/java/org/webbitserver/HttpListener.java
@@ -1,0 +1,15 @@
+package org.webbitserver; 
+
+/**
+ * An HttpChannel lets you monitor onclose and onopen events
+ */
+public interface HttpListener extends HttpHandler {
+        /*
+         * called when a channel is opened
+         */
+        public void onOpen (Integer channelId, HttpRequest request);
+        /*
+         * called when a channel is closed
+         */
+        public void onClose (Integer channelId);
+}

--- a/src/main/java/org/webbitserver/WebServer.java
+++ b/src/main/java/org/webbitserver/WebServer.java
@@ -65,6 +65,12 @@ public interface WebServer extends Endpoint<WebServer> {
     WebServer add(String path, HttpHandler handler);
 
     /**
+     * same as HttpHandler except the handler also gets to listen for onClose/onOpen events.
+     *
+     */
+    public WebServer add(String path, HttpListener handler);
+
+    /**
      * Add a WebSocketHandler for dealing with WebSockets.
      * <p/>
      * This is shortcut for {@code add(new PathMatchHandler(path, newHttpToWebSocketHandler(handler)))}.

--- a/src/main/java/org/webbitserver/handler/HttpHandlerToListener.java
+++ b/src/main/java/org/webbitserver/handler/HttpHandlerToListener.java
@@ -1,0 +1,22 @@
+package org.webbitserver.handler;
+
+import org.webbitserver.EventSourceHandler;
+import org.webbitserver.HttpControl;
+import org.webbitserver.HttpHandler;
+import org.webbitserver.HttpRequest;
+import org.webbitserver.HttpResponse;
+import org.webbitserver.HttpListener;
+
+public class HttpHandlerToListener implements HttpHandler {
+    private final HttpListener handler;
+
+    public HttpHandlerToListener(HttpListener handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public void handleHttpRequest(HttpRequest request, HttpResponse response, HttpControl control) throws Exception {
+        control.listener(handler);
+        handler.handleHttpRequest(request, response, control);
+    }
+}

--- a/src/main/java/org/webbitserver/netty/ListenerConnectionHandler.java
+++ b/src/main/java/org/webbitserver/netty/ListenerConnectionHandler.java
@@ -1,0 +1,40 @@
+package org.webbitserver.netty;
+
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.webbitserver.EventSourceHandler;
+import org.webbitserver.HttpListener;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.Executor;
+
+public class ListenerConnectionHandler extends SimpleChannelUpstreamHandler {
+    private final ConnectionHelper connectionHelper;
+
+    public ListenerConnectionHandler(
+            Executor executor,
+            UncaughtExceptionHandler exceptionHandler,
+            UncaughtExceptionHandler ioExceptionHandler,
+            final HttpListener listener,
+            final Integer channelId
+
+    ) {
+        this.connectionHelper = new ConnectionHelper(executor, exceptionHandler, ioExceptionHandler) {
+            @Override
+            protected void fireOnClose() throws Exception {
+                listener.onClose(channelId);
+            }
+        };
+    }
+
+    @Override
+    public void  channelUnbound(ChannelHandlerContext ctx, ChannelStateEvent e) {
+        connectionHelper.fireOnClose(e); 
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) {
+        connectionHelper.fireConnectionException(e);
+    }
+}

--- a/src/main/java/org/webbitserver/netty/NettyWebServer.java
+++ b/src/main/java/org/webbitserver/netty/NettyWebServer.java
@@ -14,11 +14,13 @@ import org.jboss.netty.handler.ssl.SslHandler;
 import org.webbitserver.EventSourceHandler;
 import org.webbitserver.HttpHandler;
 import org.webbitserver.WebServer;
+import org.webbitserver.HttpListener;
 import org.webbitserver.WebSocketHandler;
 import org.webbitserver.WebbitException;
 import org.webbitserver.handler.DateHeaderHandler;
 import org.webbitserver.handler.HttpToEventSourceHandler;
 import org.webbitserver.handler.HttpToWebSocketHandler;
+import org.webbitserver.handler.HttpHandlerToListener;
 import org.webbitserver.handler.PathMatchHandler;
 import org.webbitserver.handler.ServerHeaderHandler;
 import org.webbitserver.handler.exceptions.PrintStackTraceExceptionHandler;
@@ -160,6 +162,11 @@ public class NettyWebServer implements WebServer {
     @Override
     public NettyWebServer add(String path, EventSourceHandler handler) {
         return add(path, new HttpToEventSourceHandler(handler));
+    }
+
+    @Override
+    public NettyWebServer add(String path, HttpListener handler) {
+        return add(path, new HttpHandlerToListener(handler));
     }
 
     @Override

--- a/src/main/java/org/webbitserver/stub/StubHttpControl.java
+++ b/src/main/java/org/webbitserver/stub/StubHttpControl.java
@@ -5,6 +5,7 @@ import org.webbitserver.EventSourceHandler;
 import org.webbitserver.HttpControl;
 import org.webbitserver.HttpRequest;
 import org.webbitserver.HttpResponse;
+import org.webbitserver.HttpListener;
 import org.webbitserver.WebSocketConnection;
 import org.webbitserver.WebSocketHandler;
 
@@ -34,6 +35,7 @@ public class StubHttpControl implements HttpControl {
         this.response = response;
         this.webSocketConnection = connection;
     }
+  
 
     public HttpRequest request() {
         return request;
@@ -61,6 +63,10 @@ public class StubHttpControl implements HttpControl {
     @Override
     public void nextHandler(HttpRequest request, HttpResponse response) {
         nextHandler(request, response, this);
+    }
+    @Override
+    public void listener(HttpListener listener) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/org/webbitserver/wrapper/HttpControlWrapper.java
+++ b/src/main/java/org/webbitserver/wrapper/HttpControlWrapper.java
@@ -4,6 +4,8 @@ import org.webbitserver.EventSourceConnection;
 import org.webbitserver.EventSourceHandler;
 import org.webbitserver.HttpControl;
 import org.webbitserver.HttpRequest;
+import org.webbitserver.HttpHandler;
+import org.webbitserver.HttpListener;
 import org.webbitserver.HttpResponse;
 import org.webbitserver.WebSocketConnection;
 import org.webbitserver.WebSocketHandler;
@@ -74,6 +76,12 @@ public class HttpControlWrapper implements HttpControl {
     @Override
     public Executor handlerExecutor() {
         return control.handlerExecutor();
+    }
+
+
+    @Override
+    public void listener(HttpListener listener) {
+         control.listener(listener);
     }
 
     @Override

--- a/src/test/java/org/webbitserver/handler/HttpListenerTest.java
+++ b/src/test/java/org/webbitserver/handler/HttpListenerTest.java
@@ -1,0 +1,51 @@
+package org.webbitserver.handler;
+
+import org.junit.Test;
+import org.webbitserver.HttpControl;
+import org.webbitserver.HttpListener;
+import org.webbitserver.HttpRequest;
+import org.webbitserver.HttpResponse;
+import org.webbitserver.WebServer;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+import static org.webbitserver.WebServers.createWebServer;
+import java.util.ArrayList;
+import java.util.List;
+import static org.webbitserver.testutil.HttpClient.httpGet;
+import static org.webbitserver.testutil.HttpClient.contents;
+import java.net.URLConnection;
+
+public class HttpListenerTest {
+
+    private WebServer webServer = createWebServer(59501);
+    private List<String> ids = new ArrayList<String>();
+
+    @Test
+    public void listenerShouldBeInvoked() throws IOException, InterruptedException, ExecutionException {
+        webServer
+                .add("/foo", new HttpListener() {
+                    public void handleHttpRequest(HttpRequest request, HttpResponse response, HttpControl control)
+                            throws Exception {
+                        ids.add("handleHttpRequest");
+                        response.end();
+                    }
+                    public void onOpen (Integer channelId, HttpRequest request) {
+                        ids.add(Integer.toString(channelId));
+                    }
+                    public void onClose (Integer channelId) {
+                        ids.add(Integer.toString(channelId));
+                        ids.add("end");
+                    }
+                }).start().get();
+        URLConnection urlConnection = httpGet(webServer, "/foo"); 
+        contents(urlConnection);      
+        webServer.stop().get();  
+        assertTrue(ids.size() == 4);
+        assertTrue(ids.get(1).equals("handleHttpRequest"));
+        assertTrue(ids.get(0).equals(ids.get(2)));
+        assertTrue(ids.get(3).equals("end"));
+    }
+}

--- a/src/test/java/samples/hello/Hello.java
+++ b/src/test/java/samples/hello/Hello.java
@@ -1,0 +1,17 @@
+package samples.hello;
+
+import org.webbitserver.*;
+
+public class Hello implements HttpListener{
+
+    public void onOpen(Integer id, HttpRequest request) {
+        System.out.println("onOpen:"+ Integer.toString(id));
+    }
+    public void onClose(Integer id) {
+        System.out.println("onclose:"+ Integer.toString(id));
+    }
+    public void handleHttpRequest(HttpRequest request, HttpResponse response, HttpControl control) throws Exception {
+        System.out.println("handleHttpRequest");
+        response.content("Hello World").end();
+    }
+}

--- a/src/test/java/samples/hello/Main.java
+++ b/src/test/java/samples/hello/Main.java
@@ -1,0 +1,20 @@
+package samples.hello;
+
+import org.webbitserver.WebServer;
+import org.webbitserver.handler.StaticFileHandler;
+import org.webbitserver.handler.logging.LoggingHandler;
+import org.webbitserver.handler.logging.SimpleLogSink;
+
+import static org.webbitserver.WebServers.createWebServer;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        WebServer webServer = createWebServer(9876)
+                .add("/", new Hello())
+                .start().get();
+
+        System.out.println("Hello app  running on: " + webServer.getUri());
+    }
+
+}


### PR DESCRIPTION
the role of the listener is to provide `onClose`/`onOpen` callbacks with the exposed channel id. This is necessary in order to keep track of connected users in cases of long polling or streaming via chunked responses. 

This changeset introduces a `hello` world sample app as well.
