### PR TITLE
Fixed a cyclical error when flushing an error and flushing fails.

### DIFF
--- a/src/main/java/org/webbitserver/netty/NettyHttpResponse.java
+++ b/src/main/java/org/webbitserver/netty/NettyHttpResponse.java
@@ -166,8 +166,13 @@ public class NettyHttpResponse implements org.webbitserver.HttpResponse {
         String message = getStackTrace(error);
         header("Content-Type", "text/plain");
         content(message);
-        flushResponse();
-
+        try{
+            flushResponse();
+        }catch (IllegalStateException e){
+            return null;
+        }catch (WebbitException e){
+            return null;
+        }
         exceptionHandler.uncaughtException(Thread.currentThread(),
                 WebbitException.fromException(error, ctx.getChannel()));
 


### PR DESCRIPTION
Added a try catch around flushResponse() in error(Throwable error) which can cause cyclical errors where one error causes another because it fails when flushing. 

Following is the stack trace for the expection:

org.webbitserver.WebbitException: cannot send more responses than requests on [id: 0x4be70e4d, /10.0.0.1:57648 :> /10.0.0.99:1234]
    at org.webbitserver.WebbitException.fromException(WebbitException.java:36)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:170)
    at org.webbitserver.netty.NettyHttpChannelHandler$3.run(NettyHttpChannelHandler.java:94)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:98)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:207)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:637)
Caused by: java.lang.IllegalStateException: cannot send more responses than requests
    at org.jboss.netty.handler.codec.http.HttpContentEncoder.writeRequested(HttpContentEncoder.java:100)
    at org.jboss.netty.channel.Channels.write(Channels.java:704)
    at org.jboss.netty.channel.Channels.write(Channels.java:671)
    at org.jboss.netty.channel.AbstractChannel.write(AbstractChannel.java:248)
    at org.webbitserver.netty.NettyHttpResponse.write(NettyHttpResponse.java:207)
    at org.webbitserver.netty.NettyHttpResponse.flushResponse(NettyHttpResponse.java:195)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:168)
    ... 9 more
org.webbitserver.WebbitException: cannot send more responses than requests on [id: 0x4be70e4d, /10.0.0.1:57648 :> /10.0.0.99:1234]
    at org.webbitserver.WebbitException.fromException(WebbitException.java:36)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:170)
    at org.webbitserver.netty.NettyHttpChannelHandler$3.run(NettyHttpChannelHandler.java:94)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:98)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:207)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:637)
Caused by: java.lang.IllegalStateException: cannot send more responses than requests
    at org.jboss.netty.handler.codec.http.HttpContentEncoder.writeRequested(HttpContentEncoder.java:100)
    at org.jboss.netty.channel.Channels.write(Channels.java:704)
    at org.jboss.netty.channel.Channels.write(Channels.java:671)
    at org.jboss.netty.channel.AbstractChannel.write(AbstractChannel.java:248)
    at org.webbitserver.netty.NettyHttpResponse.write(NettyHttpResponse.java:207)
    at org.webbitserver.netty.NettyHttpResponse.flushResponse(NettyHttpResponse.java:195)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:168)
    ... 9 more
org.webbitserver.WebbitException: cannot send more responses than requests on [id: 0x4be70e4d, /10.0.0.1:57648 :> /10.0.0.99:1234]
    at org.webbitserver.WebbitException.fromException(WebbitException.java:36)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:170)
    at org.webbitserver.netty.NettyHttpChannelHandler$3.run(NettyHttpChannelHandler.java:94)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:98)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:207)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:637)
Caused by: java.lang.IllegalStateException: cannot send more responses than requests
    at org.jboss.netty.handler.codec.http.HttpContentEncoder.writeRequested(HttpContentEncoder.java:100)
    at org.jboss.netty.channel.Channels.write(Channels.java:704)
    at org.jboss.netty.channel.Channels.write(Channels.java:671)
    at org.jboss.netty.channel.AbstractChannel.write(AbstractChannel.java:248)
    at org.webbitserver.netty.NettyHttpResponse.write(NettyHttpResponse.java:207)
    at org.webbitserver.netty.NettyHttpResponse.flushResponse(NettyHttpResponse.java:195)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:168)
    ... 9 more
org.webbitserver.WebbitException: cannot send more responses than requests on [id: 0x4be70e4d, /10.0.0.1:57648 :> /10.0.0.99:1234]
    at org.webbitserver.WebbitException.fromException(WebbitException.java:36)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:170)
    at org.webbitserver.netty.NettyHttpChannelHandler$3.run(NettyHttpChannelHandler.java:94)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:98)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:207)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:637)
Caused by: java.lang.IllegalStateException: cannot send more responses than requests
    at org.jboss.netty.handler.codec.http.HttpContentEncoder.writeRequested(HttpContentEncoder.java:100)
    at org.jboss.netty.channel.Channels.write(Channels.java:704)
    at org.jboss.netty.channel.Channels.write(Channels.java:671)
    at org.jboss.netty.channel.AbstractChannel.write(AbstractChannel.java:248)
    at org.webbitserver.netty.NettyHttpResponse.write(NettyHttpResponse.java:207)
    at org.webbitserver.netty.NettyHttpResponse.flushResponse(NettyHttpResponse.java:195)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:168)
    ... 9 more
org.webbitserver.WebbitException: cannot send more responses than requests on [id: 0x4be70e4d, /10.0.0.1:57648 :> /10.0.0.99:1234]
    at org.webbitserver.WebbitException.fromException(WebbitException.java:36)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:170)
    at org.webbitserver.netty.NettyHttpChannelHandler$3.run(NettyHttpChannelHandler.java:94)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:441)
    at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
    at java.util.concurrent.FutureTask.run(FutureTask.java:138)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:98)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:207)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:637)
Caused by: java.lang.IllegalStateException: cannot send more responses than requests
    at org.jboss.netty.handler.codec.http.HttpContentEncoder.writeRequested(HttpContentEncoder.java:100)
    at org.jboss.netty.channel.Channels.write(Channels.java:704)
    at org.jboss.netty.channel.Channels.write(Channels.java:671)
    at org.jboss.netty.channel.AbstractChannel.write(AbstractChannel.java:248)
    at org.webbitserver.netty.NettyHttpResponse.write(NettyHttpResponse.java:207)
    at org.webbitserver.netty.NettyHttpResponse.flushResponse(NettyHttpResponse.java:195)
    at org.webbitserver.netty.NettyHttpResponse.error(NettyHttpResponse.java:168)
    ... 9 more
