### PR TITLE
PathMatchHandler will hand off control to the next handler when a request has an invalid URI

### DIFF
--- a/src/main/java/org/webbitserver/handler/PathMatchHandler.java
+++ b/src/main/java/org/webbitserver/handler/PathMatchHandler.java
@@ -23,11 +23,21 @@ public class PathMatchHandler implements HttpHandler {
         this(Pattern.compile(path), httpHandler);
     }
 
+    public Boolean pathIsAMatch(HttpRequest request){
+        try {
+            String path = URI.create(request.uri()).getPath();
+            Matcher matcher = pathPattern.matcher(path);
+            if (matcher.matches()) {
+                return true;
+            }
+        } catch (IllegalArgumentException e) {
+        }
+        return false;
+    }
+
     @Override
     public void handleHttpRequest(HttpRequest request, HttpResponse response, HttpControl control) throws Exception {
-        String path = URI.create(request.uri()).getPath();
-        Matcher matcher = pathPattern.matcher(path);
-        if (matcher.matches()) {
+        if (pathIsAMatch(request)) {
             httpHandler.handleHttpRequest(request, response, control);
         } else {
             control.nextHandler();

--- a/src/test/java/org/webbitserver/handler/PathMatchHandlerTest.java
+++ b/src/test/java/org/webbitserver/handler/PathMatchHandlerTest.java
@@ -54,6 +54,21 @@ public class PathMatchHandlerTest {
     }
 
     @Test
+    public void handsOffWhenIllegalURIPath() throws Exception {
+        HttpHandler handler = mock(HttpHandler.class);
+        PathMatchHandler pmh = new PathMatchHandler("/hello", handler);
+
+        HttpRequest req = new StubHttpRequest("//");
+        HttpResponse res = new StubHttpResponse();
+        HttpControl ctl = mock(HttpControl.class);
+
+        pmh.handleHttpRequest(req, res, ctl);
+
+        verifyZeroInteractions(handler);
+        verify(ctl).nextHandler();
+    }
+
+    @Test
     public void handsOffWhenNoMatch() throws Exception {
         HttpHandler handler = mock(HttpHandler.class);
         PathMatchHandler pmh = new PathMatchHandler("/hello", handler);


### PR DESCRIPTION
Currently a request to webbit server with an invalid URI such as http://hostname// (double slash) will cause the PathMatchHandler to throw an exception when URI.create(request.uri()) is called.

By catching this exception and handing off control to the next handler an application can better decide how to deal with this request.
