### PR TITLE
return empty content for 304 (fixes #138)

### DIFF
--- a/src/main/java/org/webbitserver/handler/StaticFileHandler.java
+++ b/src/main/java/org/webbitserver/handler/StaticFileHandler.java
@@ -162,6 +162,7 @@ public class StaticFileHandler extends AbstractResourceHandler {
                 if (request.header("If-Modified-Since") != null) {
                     if (fromHeader(request.header("If-Modified-Since")).getTime() >= lastModified.getTime() ) {
                         response.status(304);
+                        return new byte[]{};
                     }
                 }
                 //is setting cache control necessary?

--- a/src/test/java/org/webbitserver/handler/StaticFileHandlerTest.java
+++ b/src/test/java/org/webbitserver/handler/StaticFileHandlerTest.java
@@ -217,6 +217,7 @@ public class StaticFileHandlerTest {
         assertEquals(true, handle(request("/index_cache.html")).header("Expires") != null);
         assertEquals(true, handleWithHeader(request("/index_cache.html"), "If-Modified-Since", toDateHeader(new Date(aYearAgo))).status() == 200);
         assertEquals(true, handleWithHeader(request("/index_cache.html"), "If-Modified-Since", toDateHeader(new Date(aYearFromNow))).status() == 304);
+        assertEquals(0, handleWithHeader(request("/index_cache.html"), "If-Modified-Since", toDateHeader(new Date(aYearFromNow))).contents().length);
     }
 
     @Test


### PR DESCRIPTION
It appears that when content is returned for responses that should not have content, it manifests as garbled responses such as those that show up in #138.